### PR TITLE
Release swift-package-list 2.2.0

### DIFF
--- a/Formula/swift-package-list.rb
+++ b/Formula/swift-package-list.rb
@@ -1,8 +1,8 @@
 class SwiftPackageList < Formula
   desc "A command-line tool to generate a JSON, PLIST, Settings.bundle or PDF file with all used SPM-dependencies of an Xcode project or workspace."
   homepage "https://github.com/FelixHerrmann/swift-package-list"
-  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/2.1.3/swift-package-list.tar.gz"
-  sha256 "6ed9cdb4d84186c4c22c8387ae06cf748805b9718b57d5cb7955961595f683e4"
+  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/2.2.0/swift-package-list.tar.gz"
+  sha256 "c3c91f1609aa29f1086424d5cc502ae093915a50c9a1573ee6dbffb33e55ee5f"
   license "MIT"
 
   def install


### PR DESCRIPTION
This automated PR will update swift-package-list to version 2.2.0.