### PR TITLE
Release swift-package-list 2.2.0

### DIFF
--- a/Formula/swift-package-list.rb
+++ b/Formula/swift-package-list.rb
@@ -1,8 +1,8 @@
 class SwiftPackageList < Formula
   desc "A command-line tool to generate a JSON, PLIST, Settings.bundle or PDF file with all used SPM-dependencies of an Xcode project or workspace."
   homepage "https://github.com/FelixHerrmann/swift-package-list"
-  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/2.1.3/swift-package-list.tar.gz"
-  sha256 "6ed9cdb4d84186c4c22c8387ae06cf748805b9718b57d5cb7955961595f683e4"
+  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/2.2.0/swift-package-list.tar.gz"
+  sha256 "a1b2c20881903512a06d99c8918750f491b016ad370dcbc1772a896acf2f3086"
   license "MIT"
 
   def install


### PR DESCRIPTION
This automated PR will update swift-package-list to version 2.2.0.