### PR TITLE
Release swift-package-list 3.0.2

### DIFF
--- a/Formula/swift-package-list.rb
+++ b/Formula/swift-package-list.rb
@@ -1,8 +1,8 @@
 class SwiftPackageList < Formula
   desc "A command-line tool to generate a JSON, PLIST, Settings.bundle or PDF file with all used SPM-dependencies of an Xcode project or workspace."
   homepage "https://github.com/FelixHerrmann/swift-package-list"
-  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/3.0.1/swift-package-list.tar.gz"
-  sha256 "b02413c50a5efbd9b5be5dff16151ca2df8a2644a758fd93c73c10cf98db26e2"
+  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/3.0.2/swift-package-list.tar.gz"
+  sha256 "1633937342907a9c290aa2b50def1043eb42915af148aabaab49891c2bce471b"
   license "MIT"
 
   def install


### PR DESCRIPTION
This automated PR will update swift-package-list to version 3.0.2.