### PR TITLE
Release swift-package-list 3.0.6

### DIFF
--- a/Formula/swift-package-list.rb
+++ b/Formula/swift-package-list.rb
@@ -1,8 +1,8 @@
 class SwiftPackageList < Formula
   desc "A command-line tool to generate a JSON, PLIST, Settings.bundle or PDF file with all used SPM-dependencies of an Xcode project or workspace."
   homepage "https://github.com/FelixHerrmann/swift-package-list"
-  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/3.0.5/swift-package-list.tar.gz"
-  sha256 "a1198815643a01b60acdd78926fa3e02ffb08f52b8d1eb924a24fe84689a0cf2"
+  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/3.0.6/swift-package-list.tar.gz"
+  sha256 "bc4f4f33ebf317ca05f4fc4c76c13195d87b5d39fd782422a74ab4436a81367b"
   license "MIT"
 
   def install


### PR DESCRIPTION
This automated PR will update swift-package-list to version 3.0.6.