### PR TITLE
Release swift-package-list 3.0.8

### DIFF
--- a/Formula/swift-package-list.rb
+++ b/Formula/swift-package-list.rb
@@ -1,8 +1,8 @@
 class SwiftPackageList < Formula
   desc "A command-line tool to generate a JSON, PLIST, Settings.bundle or PDF file with all used SPM-dependencies of an Xcode project or workspace."
   homepage "https://github.com/FelixHerrmann/swift-package-list"
-  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/3.0.7/swift-package-list.tar.gz"
-  sha256 "29ed4b65e79db0634f84a00bff812f60d1f54ac3cc3dae99e2bba7abaaf939b5"
+  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/3.0.8/swift-package-list.tar.gz"
+  sha256 "bd5860710f7de64eeaa5e564d0b57306ed2cb3bf15e27b20d71fb88ba60d4659"
   license "MIT"
 
   def install


### PR DESCRIPTION
This automated PR will update swift-package-list to version 3.0.8.