### PR TITLE
Release swift-package-list 3.0.9

### DIFF
--- a/Formula/swift-package-list.rb
+++ b/Formula/swift-package-list.rb
@@ -1,8 +1,8 @@
 class SwiftPackageList < Formula
   desc "A command-line tool to generate a JSON, PLIST, Settings.bundle or PDF file with all used SPM-dependencies of an Xcode project or workspace."
   homepage "https://github.com/FelixHerrmann/swift-package-list"
-  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/3.0.8/swift-package-list.tar.gz"
-  sha256 "bd5860710f7de64eeaa5e564d0b57306ed2cb3bf15e27b20d71fb88ba60d4659"
+  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/3.0.9/swift-package-list.tar.gz"
+  sha256 "2fda6e4aa7f6420bb94eb006006cc2daa0f3360c074f0d7316909df3e4e9cd13"
   license "MIT"
 
   def install


### PR DESCRIPTION
This automated PR will update swift-package-list to version 3.0.9.