### PR TITLE
Release swift-package-list 3.1.0

### DIFF
--- a/Formula/swift-package-list.rb
+++ b/Formula/swift-package-list.rb
@@ -1,8 +1,8 @@
 class SwiftPackageList < Formula
   desc "A command-line tool to generate a JSON, PLIST, Settings.bundle or PDF file with all used SPM-dependencies of an Xcode project or workspace."
   homepage "https://github.com/FelixHerrmann/swift-package-list"
-  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/3.0.10/swift-package-list.tar.gz"
-  sha256 "115a6f8524b5e79155f07540e61ea50d927d3fb4fd3ea1d7189f7e1c1a71e51f"
+  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/3.1.0/swift-package-list.tar.gz"
+  sha256 "1c1370f7599098d0cb1ae31f07693fea654ce0180307c6128471b4176c47bd99"
   license "MIT"
 
   def install


### PR DESCRIPTION
This automated PR will update swift-package-list to version 3.1.0.