### PR TITLE
Release swift-package-list 4.2.0

### DIFF
--- a/Formula/swift-package-list.rb
+++ b/Formula/swift-package-list.rb
@@ -1,8 +1,8 @@
 class SwiftPackageList < Formula
   desc "A command-line tool to generate a JSON, PLIST, Settings.bundle or PDF file with all used SPM-dependencies of an Xcode project or workspace."
   homepage "https://github.com/FelixHerrmann/swift-package-list"
-  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/4.1.0/swift-package-list.tar.gz"
-  sha256 "2b2db0596febd8b2f70bc12db961a530994ca81903e99656fffd41b67f1252ed"
+  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/4.2.0/swift-package-list.tar.gz"
+  sha256 "645226f812fe6c912b0a95e61240bf479e207889366e2f0ce6d8037518540cf4"
   license "MIT"
 
   def install


### PR DESCRIPTION
This automated PR will update swift-package-list to version 4.2.0.