### PR TITLE
Release swift-package-list 4.3.0

### DIFF
--- a/Formula/swift-package-list.rb
+++ b/Formula/swift-package-list.rb
@@ -1,8 +1,8 @@
 class SwiftPackageList < Formula
   desc "A command-line tool to generate a JSON, PLIST, Settings.bundle or PDF file with all used SPM-dependencies of an Xcode project or workspace."
   homepage "https://github.com/FelixHerrmann/swift-package-list"
-  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/4.2.0/swift-package-list.tar.gz"
-  sha256 "645226f812fe6c912b0a95e61240bf479e207889366e2f0ce6d8037518540cf4"
+  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/4.3.0/swift-package-list.tar.gz"
+  sha256 "8b9511847b976ed605d0cd0e2916cc51d1370f9099752fb27446f63502f72770"
   license "MIT"
 
   def install


### PR DESCRIPTION
This automated PR will update swift-package-list to version 4.3.0.