### PR TITLE
Release swift-package-list 4.4.0

### DIFF
--- a/Formula/swift-package-list.rb
+++ b/Formula/swift-package-list.rb
@@ -1,8 +1,8 @@
 class SwiftPackageList < Formula
   desc "A command-line tool to generate a JSON, PLIST, Settings.bundle or PDF file with all used SPM-dependencies of an Xcode project or workspace."
   homepage "https://github.com/FelixHerrmann/swift-package-list"
-  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/4.3.0/swift-package-list.tar.gz"
-  sha256 "8b9511847b976ed605d0cd0e2916cc51d1370f9099752fb27446f63502f72770"
+  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/4.4.0/swift-package-list.tar.gz"
+  sha256 "5b9b65fbf6e1c58f46950dddb73c60693a4e969b1c03c2b8b750454e1c64e570"
   license "MIT"
 
   def install


### PR DESCRIPTION
This automated PR will update swift-package-list to version 4.4.0.