### PR TITLE
Release swift-package-list 4.6.0

### DIFF
--- a/Formula/swift-package-list.rb
+++ b/Formula/swift-package-list.rb
@@ -1,8 +1,8 @@
 class SwiftPackageList < Formula
   desc "A command-line tool to generate a JSON, PLIST, Settings.bundle or PDF file with all used SPM-dependencies of an Xcode project or workspace."
   homepage "https://github.com/FelixHerrmann/swift-package-list"
-  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/4.5.0/swift-package-list.tar.gz"
-  sha256 "ea7da62d7bd176c4225660965b05b0aa1dac2d37f0800610fc2623731767b1a2"
+  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/4.6.0/swift-package-list.tar.gz"
+  sha256 "67d473013bf2af269172d5953fa05e66a929dcfeed4acf8685f33ca26d744b93"
   license "MIT"
 
   def install


### PR DESCRIPTION
This automated PR will update swift-package-list to version 4.6.0.