### PR TITLE
Release swift-package-list 4.7.0

### DIFF
--- a/Formula/swift-package-list.rb
+++ b/Formula/swift-package-list.rb
@@ -1,8 +1,8 @@
 class SwiftPackageList < Formula
   desc "A command-line tool to generate a JSON, PLIST, Settings.bundle or PDF file with all used SPM-dependencies of an Xcode project or workspace."
   homepage "https://github.com/FelixHerrmann/swift-package-list"
-  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/4.6.0/swift-package-list.tar.gz"
-  sha256 "67d473013bf2af269172d5953fa05e66a929dcfeed4acf8685f33ca26d744b93"
+  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/4.7.0/swift-package-list.tar.gz"
+  sha256 "787a38af286aa766d17ff2e34dd5924157c3ab653efb9a5ab6950b1c80dcde63"
   license "MIT"
 
   def install


### PR DESCRIPTION
This automated PR will update swift-package-list to version 4.7.0.