### PR TITLE
Release swift-package-list 4.7.1

### DIFF
--- a/Formula/swift-package-list.rb
+++ b/Formula/swift-package-list.rb
@@ -1,8 +1,8 @@
 class SwiftPackageList < Formula
   desc "A command-line tool to generate a JSON, PLIST, Settings.bundle or PDF file with all used SPM-dependencies of an Xcode project or workspace."
   homepage "https://github.com/FelixHerrmann/swift-package-list"
-  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/4.7.0/swift-package-list.tar.gz"
-  sha256 "787a38af286aa766d17ff2e34dd5924157c3ab653efb9a5ab6950b1c80dcde63"
+  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/4.7.1/swift-package-list.tar.gz"
+  sha256 "1c287305dd24131834bbbef3d13dae1df65bf3f9814c8b1a1a8c95d7ec098358"
   license "MIT"
 
   def install


### PR DESCRIPTION
This automated PR will update swift-package-list to version 4.7.1.