### PR TITLE
Release swift-package-list 4.7.2

### DIFF
--- a/Formula/swift-package-list.rb
+++ b/Formula/swift-package-list.rb
@@ -1,8 +1,8 @@
 class SwiftPackageList < Formula
   desc "A command-line tool to generate a JSON, PLIST, Settings.bundle or PDF file with all used SPM-dependencies of an Xcode project or workspace."
   homepage "https://github.com/FelixHerrmann/swift-package-list"
-  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/4.7.1/swift-package-list.tar.gz"
-  sha256 "1c287305dd24131834bbbef3d13dae1df65bf3f9814c8b1a1a8c95d7ec098358"
+  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/4.7.2/swift-package-list.tar.gz"
+  sha256 "bf7012da75c0bb97828fcaf2c66c2faa91c202f7b83587704c997e40015d9541"
   license "MIT"
 
   def install


### PR DESCRIPTION
This automated PR will update swift-package-list to version 4.7.2.