### PR TITLE
Release swift-package-list 4.8.0

### DIFF
--- a/Formula/swift-package-list.rb
+++ b/Formula/swift-package-list.rb
@@ -1,8 +1,8 @@
 class SwiftPackageList < Formula
   desc "A command-line tool to generate a JSON, PLIST, Settings.bundle or PDF file with all used SPM-dependencies of an Xcode project or workspace."
   homepage "https://github.com/FelixHerrmann/swift-package-list"
-  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/4.7.2/swift-package-list.tar.gz"
-  sha256 "bf7012da75c0bb97828fcaf2c66c2faa91c202f7b83587704c997e40015d9541"
+  url "https://github.com/FelixHerrmann/swift-package-list/releases/download/4.8.0/swift-package-list.tar.gz"
+  sha256 "819db36e5fe3da793205c7d492f433d496652671177f5fe52c3d8f1ab2c72baf"
   license "MIT"
 
   def install


### PR DESCRIPTION
This automated PR will update swift-package-list to version 4.8.0.